### PR TITLE
Fix homepage logo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,7 @@ module.exports = {
       logo: {
         alt: 'SAP Cloud SDK for AI',
         src: 'img/AI-SDK-Logo.svg',
-        srcDark: 'img/logo-dark.svg'
+        srcDark: 'img/AI-SDK-Logo.svg'
       },
       items: [
         {


### PR DESCRIPTION
## What Has Changed?

When using dark mode, the logo was not showing up.
