### PR TITLE
Java: Readable OpenAI docs

### DIFF
--- a/docs-java/foundation-models/openai/chat-completion.mdx
+++ b/docs-java/foundation-models/openai/chat-completion.mdx
@@ -21,7 +21,8 @@ This means that these model classes are not guaranteed to be stable and may chan
 They are safe to use, but may require updates even in minor releases.
 :::
 
-### New User Interface (v1.4.0)
+<details>
+<summary>New User Interface (v1.4.0)</summary>
 
 We're excited to introduce a new user interface for OpenAI chat completions starting with **version 1.4.0**. This update is designed to improve the SAP AI SDK by:
 
@@ -34,6 +35,8 @@ We're excited to introduce a new user interface for OpenAI chat completions star
 - The new interface is gradually being rolled out across the SAP AI SDK.
 - We welcome your feedback to help us refine this interface.
 - The existing interface (v1.0.0) remains available for compatibility.
+
+</details>
 
 ## Prerequisites
 

--- a/docs-java/foundation-models/openai/embedding.mdx
+++ b/docs-java/foundation-models/openai/embedding.mdx
@@ -21,7 +21,8 @@ This means that these model classes are not guaranteed to be stable and may chan
 They are safe to use, but may require updates even in minor releases.
 :::
 
-### New User Interface (v1.4.0)
+<details>
+<summary>New User Interface (v1.4.0)</summary>
 
 We're excited to introduce a new user interface for OpenAI embedding calls starting with **version 1.4.0**. This update is designed to improve the SAP AI SDK by:
 
@@ -34,6 +35,8 @@ We're excited to introduce a new user interface for OpenAI embedding calls start
 - The new interface is gradually being rolled out across the SAP AI SDK.
 - We welcome your feedback to help us refine this interface.
 - The existing interface (v1.0.0) remains available for compatibility.
+
+</details>
 
 ## Prerequisites
 


### PR DESCRIPTION
## What Has Changed?

The embedding docs was 3 pages long, but the only useful info is 3 lines of sample code. I made the docs shorter
