### PR TITLE
Java: remove mention of `@Beta` annotations

### DIFF
--- a/docs-java/ai-core/ai-core-deployment.mdx
+++ b/docs-java/ai-core/ai-core-deployment.mdx
@@ -16,7 +16,7 @@ keywords:
 This guide provides examples on how to create and manage deployments in SAP AI Core using the SAP AI SDK for Java.
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::

--- a/docs-java/ai-core/document-grounding.mdx
+++ b/docs-java/ai-core/document-grounding.mdx
@@ -17,7 +17,7 @@ This guide provides examples on how to manage data in SAP Document Grounding.
 It's divided into two main sections: Data Ingestion and Data Retrieval.
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::

--- a/docs-java/ai-core/prompt-registry.mdx
+++ b/docs-java/ai-core/prompt-registry.mdx
@@ -16,7 +16,7 @@ keywords:
 This guide provides examples on how to manage the life cycle of your prompts, from design to runtime in [Prompt Registry](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/prompt-registry).
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::

--- a/docs-java/foundation-models/openai/chat-completion.mdx
+++ b/docs-java/foundation-models/openai/chat-completion.mdx
@@ -16,7 +16,7 @@ keywords:
 This guide demonstrates how to use the SAP AI SDK for Java to perform chat completion tasks using OpenAI models deployed on SAP AI Core.
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::
@@ -34,7 +34,7 @@ We're excited to introduce a new user interface for OpenAI chat completions star
 
 - The new interface is gradually being rolled out across the SAP AI SDK.
 - We welcome your feedback to help us refine this interface.
-- The existing interface (v1.0.0) remains available for compatibility.
+- The existing interface (v1.0.0) is deprecated but available.
 
 </details>
 

--- a/docs-java/foundation-models/openai/embedding.mdx
+++ b/docs-java/foundation-models/openai/embedding.mdx
@@ -16,7 +16,7 @@ keywords:
 This guide demonstrates how to use the SAP AI SDK for Java to perform embedding tasks using OpenAI models deployed on SAP AI Core.
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::
@@ -34,7 +34,7 @@ We're excited to introduce a new user interface for OpenAI embedding calls start
 
 - The new interface is gradually being rolled out across the SAP AI SDK.
 - We welcome your feedback to help us refine this interface.
-- The existing interface (v1.0.0) remains available for compatibility.
+- The existing interface (v1.0.0) is deprecated but available.
 
 </details>
 

--- a/docs-java/orchestration/chat-completion.mdx
+++ b/docs-java/orchestration/chat-completion.mdx
@@ -20,7 +20,7 @@ This guide provides examples of how to use the [Orchestration service in SAP AI 
 For detailed information on the individual capabilities of the Orchestration service, please refer to the [official documentation](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/orchestration-workflow).
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::

--- a/docs-java/release-notes/release-notes-0-to-14.mdx
+++ b/docs-java/release-notes/release-notes-0-to-14.mdx
@@ -127,7 +127,7 @@
   - Generate embeddings for input text.
 
 :::warning
-All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
+All classes under any of the `...model` packages are generated from an OpenAPI specification.
 This means that these model classes are not guaranteed to be stable and may change with future releases.
 They are safe to use, but may require updates even in minor releases.
 :::


### PR DESCRIPTION
## What Has Changed?

Review our beta annotation and reduce the number of annotation to make the "beta" warning more meaningful.

See:
- https://github.com/SAP/ai-sdk-java/pull/413
- https://github.com/SAP/ai-sdk-java/pull/414
