### PR TITLE
[Java] docs: Add docs about local prompt templates

### DIFF
--- a/docs-java/ai-core/prompt-registry.mdx
+++ b/docs-java/ai-core/prompt-registry.mdx
@@ -158,3 +158,8 @@ PromptTemplateDeleteResponse response = client.deletePromptTemplate(template.get
 ```
 
 Refer to the [PromptRegistryController.java](https://github.com/SAP/ai-sdk-java/tree/main/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/PromptRegistryController.java) in our Spring Boot application for a complete example.
+
+## Locally Test a Prompt Template
+
+Note that you can also locally test a prompt, without needing it to be deployed in the Prompt Registry.
+For more information, see [the Orchestration documentation](../orchestration/chat-completion#locally-test-a-prompt-template).

--- a/docs-java/orchestration/chat-completion.mdx
+++ b/docs-java/orchestration/chat-completion.mdx
@@ -167,6 +167,8 @@ var result = client.chatCompletion(prompt, configWithTemplate);
 
 In this case the template is defined with the placeholder `{{?language}}` which is replaced by the value `German` in the input parameters.
 
+### Prompt Templates from Prompt Registry
+
 Alternatively, you can use already prepared templates from the [**Prompt Registry**](../ai-core/prompt-registry) of SAP AI Core instead of passing a template in the request yourself.
 
 ```java
@@ -183,6 +185,41 @@ A prompt template can be referenced either by ID as above, or by using a combina
 For details on storing a template in the Prompt Registry, refer to [this guide](https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/create-prompt-template-imperative).
 
 You can find [some examples](https://github.com/SAP/ai-sdk-java/tree/main/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java) in our Spring Boot application demonstrating using templates from Prompt Registry.
+
+### Locally Test a Prompt Template
+
+You can also test prompt templates in YAML format locally without using the prompt registry.
+This can be helpful, for example, if you want to quickly iterate over a prompt template before uploading it.
+
+```Java
+String promptTemplate = """
+name: translator
+version: 0.0.1
+scenario: translation scenario
+spec:
+  template:
+    - role: "system"
+      content: |-
+        You are a language translator.
+    - role: "user"
+      content: |-
+        Whats {{ ?word }} in {{ ?language }}?
+  defaults:
+    word: "apple"
+""";
+var template = TemplateConfig.create().fromYaml(promptTemplate);
+var configWithTemplate = template != null ? config.withTemplateConfig(template) : config;
+
+var inputParams = Map.of("language", "German");
+var prompt = new OrchestrationPrompt(inputParams);
+var response = client.chatCompletion(prompt, configWithTemplate);
+```
+
+The `fromYaml()` method will throw an exception if the YAML is not valid or does not match the spec of the Prompt Registry.
+
+Note that `additionalFields` will be ignored when using a prompt template locally like this.
+
+Please also refer to [our sample code](https://github.com/SAP/ai-sdk-java/tree/main/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java) for an implementation and more examples.
 
 ## Message History
 

--- a/docs-java/orchestration/chat-completion.mdx
+++ b/docs-java/orchestration/chat-completion.mdx
@@ -208,7 +208,7 @@ spec:
     word: "apple"
 """;
 var template = TemplateConfig.create().fromYaml(promptTemplate);
-var configWithTemplate = template != null ? config.withTemplateConfig(template) : config;
+var configWithTemplate = config.withTemplateConfig(template);
 
 var inputParams = Map.of("language", "German");
 var prompt = new OrchestrationPrompt(inputParams);


### PR DESCRIPTION
## What Has Changed?

Adds documentation about local prompt templates: https://github.com/SAP/ai-sdk-java/pull/423
