### PR TITLE
chore: [JS] Add streaming doc for LangChain orchestration client

### DIFF
--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -71,6 +71,40 @@ const response = await client.invoke(history, {
 });
 ```
 
+## Streaming
+
+The `OrchestrationClient` LangChain client supports streaming responses for chat completion requests.
+Use the `stream()` method to receive a stream of chunk responses from the model.
+
+By default, the last chunk contains the finish reason and token usage information.
+
+```ts
+const orchestrationConfig: LangchainOrchestrationModuleConfig = {
+  llm: {
+    model_name: 'gpt-4o'
+  }
+};
+
+const client = new OrchestrationClient(orchestrationConfig);
+const response = await client.stream([
+  {
+    role: 'user',
+    content:
+      'Write a 100 word explanation about SAP Cloud SDK and its capabilities'
+  }
+]);
+
+let finalResult: AIMessageChunk | undefined;
+
+for await (const chunk of response) {
+  console.log(chunk.content);
+  finalResult = finalResult ? finalResult.concat(chunk) : chunk;
+}
+
+console.log(finalResult?.response_metadata?.finishReason);
+console.log(finalResult?.usage_metadata);
+```
+
 ## Resilience
 
 Use LangChain options such as `maxRetries` and `timeout` to provide resilience.
@@ -103,5 +137,4 @@ const response = await client.invoke(messageHistory, { timeout: 10000 });
 
 Currently unsupported features are:
 
-- Streaming
 - Tool Calling

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -176,6 +176,20 @@ To limit the maximum duration for the entire request including retries, specify 
 const response = await client.invoke(messageHistory, { timeout: 10000 });
 ```
 
+Timeout can also be set for streaming requests.
+
+```ts
+const response = await client.stream(
+  [
+    {
+      role: 'user',
+      content: 'Hello world! Why is this phrase so famous?'
+    }
+  ],
+  { timeout: 1000 }
+);
+```
+
 ## Limitations
 
 Currently unsupported features are:

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -146,7 +146,8 @@ for await (const chunk of response) {
 }
 ```
 
-In this example, streaming request will be aborted after one second. Abort controller can be useful, e.g., when end-user wants to stop the stream or refreshes the page.
+In this example, streaming request will be aborted after one second. 
+Abort controller can be useful, e.g., when end-user wants to stop the stream or refreshes the page.
 
 ## Resilience
 

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -111,6 +111,43 @@ console.log(finalResult?.response_metadata?.token_usage);
 */
 ```
 
+### Streaming with Abort Controller
+
+The client supports aborting streaming requests using the `AbortController` API.
+In case of an error, SAP Cloud SDK for AI will automatically close the stream.
+It can also be manually aborted if an `AbortSignal` object associated with an `AbortController` was provided when calling the `stream()` method.
+
+```ts
+const orchestrationConfig: LangchainOrchestrationModuleConfig = {
+  llm: {
+    model_name: 'gpt-4o'
+  }
+};
+
+const client = new OrchestrationClient(orchestrationConfig);
+const controller = new AbortController();
+const { signal } = controller;
+const response = await client.stream([
+  {
+    role: 'user',
+    content:
+      'Write a 100 word explanation about SAP Cloud SDK and its capabilities'
+  },
+  { signal }
+]);
+
+// Abort the streaming request after one second
+setTimeout(() => {
+  controller.abort();
+}, 1000);
+
+for await (const chunk of response) {
+  console.log(chunk.content);
+}
+```
+
+In this example, streaming request will be aborted after one second. Abort controller can be useful, e.g., when end-user wants to stop the stream or refreshes the page.
+
 ## Resilience
 
 Use LangChain options such as `maxRetries` and `timeout` to provide resilience.

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -146,7 +146,7 @@ for await (const chunk of response) {
 }
 ```
 
-In this example, streaming request will be aborted after one second. 
+In this example, streaming request will be aborted after one second.
 Abort controller can be useful, e.g., when end-user wants to stop the stream or refreshes the page.
 
 ## Resilience

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -102,8 +102,12 @@ for await (const chunk of response) {
   finalResult = finalResult ? finalResult.concat(chunk) : chunk;
 }
 
-console.log(finalResult?.response_metadata?.finishReason);
+console.log(finalResult?.response_metadata?.finish_reason);
 console.log(finalResult?.usage_metadata);
+
+/*
+  { input_tokens: 13, output_tokens: 30, total_tokens: 43 }
+*/
 ```
 
 ## Resilience

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -103,6 +103,7 @@ for await (const chunk of response) {
 }
 
 console.log(finalResult?.response_metadata?.finish_reason);
+
 console.log(finalResult?.usage_metadata);
 /*
   { input_tokens: 13, output_tokens: 30, total_tokens: 43 }
@@ -111,7 +112,7 @@ console.log(finalResult?.usage_metadata);
 // Token usage is also available in the response metadata
 console.log(finalResult?.response_metadata?.token_usage);
 /*
-  { completion_tokens: 122, prompt_tokens: 20, total_tokens: 142 }
+  { completion_tokens: 30, prompt_tokens: 13, total_tokens: 43 }
 */
 ```
 

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -71,7 +71,7 @@ const response = await client.invoke(history, {
 The client supports streaming responses for chat completion requests.
 Use the `stream()` method to receive a stream of chunk responses from the model.
 
-By default, the last chunk contains the `finish_reason` and token `usage` information.
+By default, the last chunk contains the finish reason and token usage information.
 The orchestration service doesn't support multiple choices during streaming.
 
 ```ts

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -104,9 +104,14 @@ for await (const chunk of response) {
 
 console.log(finalResult?.response_metadata?.finish_reason);
 console.log(finalResult?.usage_metadata);
-
 /*
   { input_tokens: 13, output_tokens: 30, total_tokens: 43 }
+*/
+
+// Token usage is also available in the response metadata
+console.log(finalResult?.response_metadata?.token_usage);
+/*
+  { completion_tokens: 122, prompt_tokens: 20, total_tokens: 142 }
 */
 ```
 

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -90,22 +90,22 @@ const response = await client.stream([
   }
 ]);
 
-let finalResult: AIMessageChunk | undefined;
+let finalChunk: AIMessageChunk | undefined;
 
 for await (const chunk of response) {
   console.log(chunk.content);
-  finalResult = finalResult ? finalResult.concat(chunk) : chunk;
+  finalChunk = chunk;
 }
 
-console.log(finalResult?.response_metadata?.finish_reason);
+console.log(finalChunk?.response_metadata?.finish_reason);
 
-console.log(finalResult?.usage_metadata);
+console.log(finalChunk?.usage_metadata);
 /*
   { input_tokens: 13, output_tokens: 30, total_tokens: 43 }
 */
 
 // Token usage is also available in the response metadata
-console.log(finalResult?.response_metadata?.token_usage);
+console.log(finalChunk?.response_metadata?.token_usage);
 /*
   { completion_tokens: 30, prompt_tokens: 13, total_tokens: 43 }
 */

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -76,7 +76,8 @@ const response = await client.invoke(history, {
 The client supports streaming responses for chat completion requests.
 Use the `stream()` method to receive a stream of chunk responses from the model.
 
-By default, the last chunk contains the finish reason and token usage information.
+By default, the last chunk contains the `finish_reason` and token `usage` information.
+The orchestration service doesn't support multiple choices during streaming.
 
 ```ts
 const orchestrationConfig: LangchainOrchestrationModuleConfig = {

--- a/docs-js/langchain/orchestration.mdx
+++ b/docs-js/langchain/orchestration.mdx
@@ -73,7 +73,7 @@ const response = await client.invoke(history, {
 
 ## Streaming
 
-The `OrchestrationClient` LangChain client supports streaming responses for chat completion requests.
+The client supports streaming responses for chat completion requests.
 Use the `stream()` method to receive a stream of chunk responses from the model.
 
 By default, the last chunk contains the finish reason and token usage information.


### PR DESCRIPTION
## What Has Changed?

Adding docs for LangChain orchestration streaming.
Merge after `1.14` is released.
