### PR TITLE
Java 1.9.0: [Orchestration] Added support for transforming a JSON output into an entity

### DIFF
--- a/docs-java/orchestration/chat-completion.mdx
+++ b/docs-java/orchestration/chat-completion.mdx
@@ -478,7 +478,7 @@ var configWithResponseSchema =
         config.withTemplateConfig(TemplateConfig.create().withJsonSchemaResponse(schema));
 
 var prompt = new OrchestrationPrompt(Message.user("Some message."));
-TestClass response = client.chatCompletion(prompt, configWithTemplate).entity(TestClass.class);
+TestClass response = client.chatCompletion(prompt, configWithTemplate).asEntity(TestClass.class);
 ```
 
 Note, that the LLM will only exactly adhere to the given schema if you use `withStrict(true)`.

--- a/docs-java/orchestration/chat-completion.mdx
+++ b/docs-java/orchestration/chat-completion.mdx
@@ -478,7 +478,7 @@ var configWithResponseSchema =
         config.withTemplateConfig(TemplateConfig.create().withJsonSchemaResponse(schema));
 
 var prompt = new OrchestrationPrompt(Message.user("Some message."));
-var response = client.chatCompletion(prompt, configWithTemplate).getContent();
+TestClass response = client.chatCompletion(prompt, configWithTemplate).entity(TestClass.class);
 ```
 
 Note, that the LLM will only exactly adhere to the given schema if you use `withStrict(true)`.


### PR DESCRIPTION
# ⚠️Merge after Java 1.9.0 has been released⚠️
## What Has Changed?

Currently, users have to manually parse a string as JSON into their class. Users can now let the AI SDK do the parsing.
