### PR TITLE
Remove overrides for `react-json-view-lite`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "overrides": {
-    "react-json-view-lite": "^2.4.1"
   }
 }


### PR DESCRIPTION
## What Has Changed?

Since we updated Docusaurus to 3.8.0 in #115, we can remove the overrides. For details, see SAP/ai-sdk-js-backlog#290.
