### PR TITLE
chore: Add tool call streaming docs

### DIFF
--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -600,6 +600,20 @@ for await (const chunk of response.stream.toContentStream()) {
 }
 ```
 
+### Streaming with Tool calls
+
+Use `getToolCalls()` to get the tool calls at the end of the stream.
+Alternatively, you can also call `getDeltaToolCalls()` on a chunk level, but since incomplete tool calls are likely useless,
+we recommend calling the `getToolCalls()` function on a response level.
+
+```ts
+for await (const _ of response.stream) {
+  console.log('Waiting for the stream to end ...');
+}
+
+const toolCalls = response.getToolCalls();
+```
+
 ### Streaming with Abort Controller
 
 Streaming request can be aborted using the `AbortController` API.


### PR DESCRIPTION
## What Has Changed?

With this PR, we add documentation on how to use tool calls with streaming enabled in the orchestration client.

Solves https://github.com/SAP/ai-sdk-js-backlog/issues/326