### PR TITLE
chore: remove extra formatting from FAQ headers

### DIFF
--- a/docs-java/faq.mdx
+++ b/docs-java/faq.mdx
@@ -12,7 +12,7 @@ keywords:
   - ai
 ---
 
-### _"How to add a custom header to AI Core requests?"_
+### How to add a custom header to AI Core requests?
 
 The SAP AI SDK leverages the destination concept from the SAP Cloud SDK for AI to manage the connection to AI Core.
 This opens up a wide range of possibilities to customize the connection, including adding custom headers.
@@ -62,13 +62,13 @@ Their API signatures may change, for example, due to updates in the underlying s
 - [Document Grounding client](https://github.com/SAP/ai-sdk-java/tree/main/core-services/document-grounding)
 - [Prompt Registry client](https://github.com/SAP/ai-sdk-java/tree/main/core-services/prompt-registry)
 
-### _"There's a vulnerability warning `CVE-2021-41251`?"_
+### There's a vulnerability warning `CVE-2021-41251`?
 
 This is a known false-positive finding.
 Depending on the tooling any product called "SAP Cloud SDK for AI" or similar with a low version number may be marked as vulnerable, incorrectly.
 Please consider suppressing the warning, [as we do](https://github.com/SAP/ai-sdk-java/blob/main/.pipeline/dependency-check-suppression.xml).
 
-### _"Are there any example projects?"_
+### Are there any example projects?
 
 Explore example applications and code snippets:
 


### PR DESCRIPTION
## What Has Changed?

* Headings in FAQ had different styles
* Standardize to md headings without additional markup
