### PR TITLE
fix: update LLM names

### DIFF
--- a/docs-java/orchestration/chat-completion.mdx
+++ b/docs-java/orchestration/chat-completion.mdx
@@ -141,9 +141,9 @@ Thanks to the harmonized API, all available LLMs on the SAP Generative AI Hub ca
 - OpenAI GPT 4o
 - OpenAI o1
 - OpenAI o3 mini
-- AWS Anthropic Claud
+- AWS Anthropic Claude
 - AWS Amazon Nova
-- GCP Gemini
+- GCP VertexAI Gemini
 - Mistral AI
   :::
 

--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -111,9 +111,9 @@ Thanks to the harmonized API, all available LLMs on the SAP Generative AI Hub ca
 - OpenAI GPT 4o
 - OpenAI o1
 - OpenAI o3 mini
-- AWS Anthropic Claud
+- AWS Anthropic Claude
 - AWS Amazon Nova
-- GCP Gemini
+- GCP VertexAI Gemini
 - Mistral AI
   :::
 


### PR DESCRIPTION
## What Has Changed?


* Tip on "Available LLMs on SAP Generative AI Hub" used inconsistent naming for model families
* Should we include the provider, such as Azure, AWS? (argubaly a user would not care)

Alternative:

```
- OpenAI GPT, e.g. 4o or o3-mini
- Anthropic Claude
- Amazon Nova
- VertexAI Gemini
- Mistral AI
```