### PR TITLE
chore: Update SpringAI Orchestration Integration code

### DIFF
--- a/docs-java/spring-ai/orchestration.mdx
+++ b/docs-java/spring-ai/orchestration.mdx
@@ -198,9 +198,9 @@ ChatModel client = new OrchestrationChatModel();
 OrchestrationModuleConfig config = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 OrchestrationChatOptions opts = new OrchestrationChatOptions(config);
 
-val repository = new InMemoryChatMemoryRepository();
-val memory = MessageWindowChatMemory.builder().chatMemoryRepository(repository).build();
-val advisor = MessageChatMemoryAdvisor.builder(memory).build();
+var repository = new InMemoryChatMemoryRepository();
+var memory = MessageWindowChatMemory.builder().chatMemoryRepository(repository).build();
+var advisor = MessageChatMemoryAdvisor.builder(memory).build();
 var cl = ChatClient.builder(client).defaultAdvisors(advisor).build();
 
 Prompt prompt1 = new Prompt("What is the capital of France?", opts);
@@ -225,16 +225,16 @@ public record Translation(
   @JsonProperty(required = true) String translation,
   @JsonProperty(required = true) String language) {}
 
-var client = new OrchestrationChatModel();
+ChatModel client = new OrchestrationChatModel();
+OrchestrationModuleConfig config = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 
-var schema = ResponseJsonSchema.fromType(Translation.class);
-var template = TemplateConfig.create().withJsonSchemaResponse(schema);
-var opts = new OrchestrationChatOptions(config.withTemplateConfig(template));
+var cl = ChatClient.builder(client).build();
+var opts = new OrchestrationChatOptions(config);
 
 var prompt =
   new Prompt("How do I say 'AI is going to revolutionize the world' in dutch?", opts);
 
-Translation translation = client.call(prompt).entity(Translation.class);
+Translation translation = cl.prompt(prompt).call().entity(Translation.class);
 ```
 
 Please find [an example in our Spring Boot application](https://github.com/SAP/ai-sdk-java/tree/main/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java).


### PR DESCRIPTION
## What Has Changed?

Updated Spring AI Orchestration Integration Response Format code by removing schema and template from our options needed to the prompt.

Regarding the task's bug, there was neither a way found to turn off the implicit Spring AI Logic nor to customize it to set the TemplateConfig automatically as ChatClient is only accessible from the sample code not from the implementation side of the Orchestration Service.

https://github.com/orgs/SAP/projects/62/views/6?pane=issue&itemId=125293847&issue=SAP%7Cai-sdk-java-backlog%7C315

