### PR TITLE
Chore: Remove beta warning

### DIFF
--- a/docs-js/ai-core/document-grounding.mdx
+++ b/docs-js/ai-core/document-grounding.mdx
@@ -12,11 +12,6 @@ keywords:
   - grounding
 ---
 
-:::warning
-This package is still in **beta** and is subject to breaking changes.
-Use it with caution.
-:::
-
 The `@sap-ai-sdk/document-grounding` package incorporates generative AI document grounding capabilities into your AI activities in SAP AI Core and SAP AI Launchpad.
 
 ## Installation

--- a/docs-js_versioned_docs/version-v1/ai-core/document-grounding.mdx
+++ b/docs-js_versioned_docs/version-v1/ai-core/document-grounding.mdx
@@ -12,11 +12,6 @@ keywords:
   - grounding
 ---
 
-:::warning
-This package is still in **beta** and is subject to breaking changes.
-Use it with caution.
-:::
-
 The `@sap-ai-sdk/document-grounding` package incorporates generative AI document grounding capabilities into your AI activities in SAP AI Core and SAP AI Launchpad.
 
 ## Installation

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,11 +1,4 @@
-const {
-  
-  ProvidePlugin
-
-
-
-
-} = require('webpack');
+const { ProvidePlugin } = require('webpack');
 
 // We have to polyfill some Node APIs because Docusaurus migrated to Webpack 5
 // This is mainly required because of remark related modules which don't load otherwise

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,11 @@
-const { ProvidePlugin } = require('webpack');
+const {
+  
+  ProvidePlugin
+
+
+
+
+} = require('webpack');
 
 // We have to polyfill some Node APIs because Docusaurus migrated to Webpack 5
 // This is mainly required because of remark related modules which don't load otherwise


### PR DESCRIPTION
## What Has Changed?

Remove beta warning for document grounding from the JS docs.

