### PR TITLE
Fix link to prerequisites

### DIFF
--- a/docs-js/tutorials/getting-started-with-agents.mdx
+++ b/docs-js/tutorials/getting-started-with-agents.mdx
@@ -30,7 +30,7 @@ The assistant performs these steps:
 
 ## Prerequisites
 
-Refer to the prerequisites outlined [here](../../overview-cloud-sdk-for-ai-js#prerequisites).
+Refer to the prerequisites outlined [here](../overview-cloud-sdk-for-ai-js#prerequisites).
 
 This tutorial assumes a basic understanding of TypeScript, LLMs, and LangChain concepts.
 


### PR DESCRIPTION
Fix link to prerequisites

## What Has Changed?

The link incorrectly used `../../` (which seems correct but is incorrect as the parent is just a grouping without influence on the URL).
