### PR TITLE
chore: [JS] add deepseek-r1 and alephalpha-pharia-1-7b-control to deprecated models

### DIFF
--- a/docs-js/overview.mdx
+++ b/docs-js/overview.mdx
@@ -103,6 +103,7 @@ Replace them with the recommended alternatives.
 | `amazon--titan-text-lite`              |                                                    |
 | `ibm--granite-13b-chat`                |                                                    |
 | `deepseek-ai--deepseek-r1`             |                                                    |
+| `alephalpha-pharia-1-7b-control`       |                                                    |
 
 ## Contribute, Support and Feedback
 

--- a/docs-js/overview.mdx
+++ b/docs-js/overview.mdx
@@ -102,6 +102,7 @@ Replace them with the recommended alternatives.
 | `amazon--titan-text-express`           |                                                    |
 | `amazon--titan-text-lite`              |                                                    |
 | `ibm--granite-13b-chat`                |                                                    |
+| `deepseek-ai--deepseek-r1`             |                                                    |
 
 ## Contribute, Support and Feedback
 


### PR DESCRIPTION
## What Has Changed?

Explain what you are changing and why, if it isn't obvious from the diff.

This PR adds `deepseek-r1` to deprecated model list as part of https://github.com/SAP/ai-sdk-js-backlog/issues/399
