### PR TITLE
[Java 1.18.0] Migrate generated API clients from Spring to Apache

### DIFF
--- a/docs-java/ai-core/prompt-registry.mdx
+++ b/docs-java/ai-core/prompt-registry.mdx
@@ -199,8 +199,8 @@ You can import a declarative prompt template as a single file export in yaml for
 ```java
 PromptClient client = new PromptClient();
 
-Resource template = new ClassPathResource("prompt-template.yaml");
-PromptTemplatePostResponse response = client.importPromptTemplate(template.getFile());
+byte[] template = new ClassPathResource("prompt-template.yaml").getContentAsByteArray();
+PromptTemplatePostResponse response = promptClient.importPromptTemplate("default", null, template);
 ```
 
 Refer to the [PromptRegistryController.java](https://github.com/SAP/ai-sdk-java/tree/main/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/PromptRegistryController.java) in our Spring Boot application for a complete example.


### PR DESCRIPTION
## What Has Changed?

The **Apache OpenAPI generator** has some breaking changes which are reflected here.
[See release notes for full list](https://github.com/SAP/ai-sdk-java/pull/795/changes#diff-3fa44f20fe1c12758e313ededbc4847b3434a9fa307dbcc493bcade14995dd5fR11)
