### PR TITLE
[Java 1.19.0] Update `importPromptTemplate` usage 

### DIFF
--- a/docs-java/ai-core/prompt-registry.mdx
+++ b/docs-java/ai-core/prompt-registry.mdx
@@ -199,7 +199,7 @@ You can import a declarative prompt template as a single file export in yaml for
 ```java
 PromptClient client = new PromptClient();
 
-byte[] template = new ClassPathResource("prompt-template.yaml").getContentAsByteArray();
+File template = new ClassPathResource("prompt-template.yaml").getFile();
 PromptTemplatePostResponse response = promptClient.importPromptTemplate("default", null, template);
 ```
 


### PR DESCRIPTION
## What Has Changed?

[Related Code Fix](https://github.com/SAP/ai-sdk-java/pull/833)

Previously `importPromptTemplate` accepted `byte[]`, but has been changed to accept `File` instead.