### PR TITLE
chore: Set permissions for GH workflows explicitly

### DIFF
--- a/.github/workflows/auto-lint-fix.yml
+++ b/.github/workflows/auto-lint-fix.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   fix-lint:
     if: github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # all write operations use app token
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # for review-dog comments
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,6 +59,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [checks]
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Context

This PR explicitly sets the least required permissions for github workflows.

Both changed runs do not have a workflow dispatch trigger, so I could not manually test them.
