### PR TITLE
docs: Update deprecated models table

### DIFF
--- a/docs-js/overview.mdx
+++ b/docs-js/overview.mdx
@@ -93,14 +93,17 @@ The following models are deprecated in SAP Cloud SDK for AI and should not be us
 Replace them with the recommended alternatives.
 For retired models, refer to the **Recently Retired Models** table in the SAP note [Availability of Generative AI Models](https://me.sap.com/notes/3437766).
 
-| Model Name                   | Replacement                                        |
-| ---------------------------- | -------------------------------------------------- |
-| `text-embedding-ada-002`     | `text-embedding-3-small`, `text-embedding-3-large` |
-| `gpt-4o-mini`                | `gpt-5-mini`                                       |
-| `amazon--titan-text-express` |                                                    |
-| `gpt-4o`                     | `gpt-5`                                            |
-| `o1`                         |                                                    |
-| `o3-mini`                    |                                                    |
+| Model Name                          | Replacement                                        |
+| ----------------------------------- | -------------------------------------------------- |
+| `text-embedding-ada-002`            | `text-embedding-3-small`, `text-embedding-3-large` |
+| `gpt-4o-mini`                       | `gpt-5-mini`                                       |
+| `gpt-4o`                            | `gpt-5`                                            |
+| `o1`                                |                                                    |
+| `o3-mini`                           |                                                    |
+| `mistralai--mistral-small-instruct` | `mistralai--mistral-small`                         |
+| `amazon--nova-premier`              | `amazon--nova-lite`                                |
+| `anthropic--claude-3-haiku`         | `anthropic--claude-4.5-haiku`                      |
+| `anthropic--claude-4-sonnet`        | `anthropic--claude-4.5-sonnet`                     |
 
 ## Contribute, Support and Feedback
 

--- a/docs-js/overview.mdx
+++ b/docs-js/overview.mdx
@@ -91,6 +91,7 @@ For a detailed list of available models, refer to the SAP note [Availability of 
 
 The following models are deprecated in SAP Cloud SDK for AI and should not be used.
 Replace them with the recommended alternatives.
+For retired models, refer to the **Recently Retired Models** table in the SAP note [Availability of Generative AI Models](https://me.sap.com/notes/3437766).
 
 | Model Name                   | Replacement                                        |
 | ---------------------------- | -------------------------------------------------- |

--- a/docs-js/overview.mdx
+++ b/docs-js/overview.mdx
@@ -92,34 +92,14 @@ For a detailed list of available models, refer to the SAP note [Availability of 
 The following models are deprecated in SAP Cloud SDK for AI and should not be used.
 Replace them with the recommended alternatives.
 
-| Model Name                             | Replacement                                                |
-| -------------------------------------- | ---------------------------------------------------------- |
-| `text-embedding-ada-002`               | `text-embedding-3-small`, `text-embedding-3-large`         |
-| `gpt-35-turbo`                         | `gpt-4.1`, `gpt-5`                                         |
-| `gpt-35-turbo-16k`                     | `gpt-5-mini`                                               |
-| `gpt-35-turbo-0125`                    | `gpt-4.1`, `gpt-5`                                         |
-| `gpt-4`                                | `gpt-4.1`, `gpt-5`                                         |
-| `gpt-4o-mini`                          | `gpt-5-mini`                                               |
-| `gemini-1.0-pro`                       | `gemini-2.5-flash`                                         |
-| `gemini-1.5-flash`                     | `gemini-2.5-flash`                                         |
-| `gemini-1.5-pro`                       | `gemini-2.5-pro`                                           |
-| `mistralai--mixtral-8x7b-instruct-v01` | `mistralai--mistral-small-instruct`                        |
-| `meta--llama3-70b-instruct`            | `mistralai--mistral-small-instruct`                        |
-| `meta--llama3.1-70b-instruct`          | `mistralai--mistral-small-instruct`                        |
-| `amazon--titan-text-express`           |                                                            |
-| `amazon--titan-text-lite`              |                                                            |
-| `ibm--granite-13b-chat`                | `mistralai--mistral-small-instruct`                        |
-| `deepseek-ai--deepseek-r1`             | `mistralai--mistral-medium-instruct`                       |
-| `alephalpha-pharia-1-7b-control`       | `mistralai--mistral-small-instruct`                        |
-| `gemini-2.0-flash`                     | <!-- list replacment `gemini-3.5-flash` when available --> |
-| `gemini-2.0-flash-lite`                | `gemini-3.1-flash-lite`                                    |
-| `anthropic--claude-3-opus`             | `anthropic--claude-4.5-opus`                               |
-| `anthropic--claude-3-sonnet`           | `anthropic--claude-4.5-sonnet`                             |
-| `anthropic--claude-3.5-sonnet`         | `anthropic--claude-4.6-sonnet`                             |
-| `anthropic--claude-3.7-sonnet`         | `anthropic--claude-4.6-sonnet`                             |
-| `gpt-4o`                               | `gpt-5`                                                    |
-| `o1`                                   |                                                            |
-| `o3-mini`                              |                                                            |
+| Model Name                   | Replacement                                        |
+| ---------------------------- | -------------------------------------------------- |
+| `text-embedding-ada-002`     | `text-embedding-3-small`, `text-embedding-3-large` |
+| `gpt-4o-mini`                | `gpt-5-mini`                                       |
+| `amazon--titan-text-express` |                                                    |
+| `gpt-4o`                     | `gpt-5`                                            |
+| `o1`                         |                                                    |
+| `o3-mini`                    |                                                    |
 
 ## Contribute, Support and Feedback
 


### PR DESCRIPTION
Sync of the deprecated models table in `docs-js/overview.mdx` from [SAP Notes 3437766](https://me.sap.com/notes/3437766).

## Changes

- Removed 21 fully retired models from the table (models now in SAP Notes "Recently Retired Models" table)
- Kept 6 active-but-deprecated models: `text-embedding-ada-002`, `gpt-4o-mini`, `amazon--titan-text-express`, `gpt-4o`, `o1`, `o3-mini`

## Definition of Done
- [x] Table entries are correct
- [x] Retired models removed
- [x] Replacement suggestions accurate