### PR TITLE
chore(renovate): try to fix preset path

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-  	"github>sap/ai-sdk-js:.github/renovate.jsonc",
+  	"github>sap/ai-sdk-js//.github/renovate.jsonc",
   	"group:docusaurusMonorepo"
   ]
 }


### PR DESCRIPTION
## What Has Changed?

Explain what you are changing and why, if it isn't obvious from the diff.
https://docs.renovatebot.com/config-presets/#github

This works
`GitHub with preset name (JSONC)	github>abc/foo:xyz.jsonc	xyz	https://github.com/abc/foo	xyz.jsonc	Default branch`
But subpath needs:
`GitHub with preset name and path	github>abc/foo//path/xyz	xyz	https://github.com/abc/foo	path/xyz.json	Default branch`

