### PR TITLE
docs(orchestration): add reasoning content documentation

### DIFF
--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -897,13 +897,14 @@ Some models can expose their intermediate reasoning steps in addition to the fin
 Enable reasoning by setting the harmonized `reasoning_effort` model parameter.
 Orchestration maps this single parameter to each provider's native reasoning configuration, so the same client code works across different models.
 
+:::note
+Anthropic Claude, GCP Gemini, and OpenAI reasoning models are among the models that expose reasoning content.
+Every reasoning model accepts the `reasoning_effort` values `minimal`, `low`, `medium`, `high`, and `none`, though each model maps them differently. You can also pass a model's native reasoning options directly.
+See the [SAP AI Core reasoning documentation](https://help.sap.com/docs/sap-ai-core/generative-ai/reasoning?locale=en-US) for details.
+:::
+
 Use the `getReasoningContent()` method to retrieve the reasoning content from the response.
 It returns an array of reasoning text blocks, or `undefined` when the model did not produce any reasoning content.
-
-:::note
-Reasoning content is only returned by models that support reasoning, such as Anthropic Claude, GCP Gemini, and OpenAI reasoning models.
-The set of supported `reasoning_effort` values (for example `low`, `medium`, and `high`) depends on the model.
-:::
 
 ```ts twoslash
 import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
@@ -929,6 +930,8 @@ if (reasoning) {
 }
 console.log(response.getContent());
 ```
+
+`getReasoningContent()` exposes only the human-readable reasoning text; any encrypted or redacted reasoning blocks the model returns are excluded.
 
 To preserve the reasoning context across turns, pass the result of `getAllMessages()` as `messagesHistory` in the next request.
 The reasoning blocks are included in the returned messages automatically, so you do not need to handle them manually.

--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -1481,7 +1481,7 @@ When streaming, reasoning content is delivered incrementally alongside the regul
 Use the `getDeltaReasoningContent()` method on each chunk to read the reasoning delta as it arrives.
 Use the `getReasoningContent()` method on the full response after the stream ends to read the accumulated reasoning content.
 
-Enable reasoning by setting the harmonized `reasoning_effort` model parameter, exactly as for non-streaming requests.
+Configure reasoning by setting the harmonized `reasoning_effort` model parameter, the same as for non-streaming requests.
 
 ```ts twoslash
 import { OrchestrationClient } from '@sap-ai-sdk/orchestration';

--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -941,7 +941,9 @@ const orchestrationClient = new OrchestrationClient({
   }
 });
 const response = await orchestrationClient.chatCompletion({
-  messages: [{ role: 'user', content: 'Explain step by step: what is 15 * 17?' }]
+  messages: [
+    { role: 'user', content: 'Explain step by step: what is 15 * 17?' }
+  ]
 });
 // ---cut---
 const followUp = await orchestrationClient.chatCompletion({

--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -1505,7 +1505,9 @@ const response = await orchestrationClient.stream({
 
 for await (const chunk of response.stream) {
   const reasoningDelta = chunk.getDeltaReasoningContent();
-  reasoningDelta?.forEach(block => console.log(`<delta-reasoning>${block}</delta-reasoning>`));
+  reasoningDelta?.forEach(block =>
+    console.log(`<delta-reasoning>${block}</delta-reasoning>`)
+  );
 }
 
 const finalReasoning = response.getReasoningContent();

--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -899,7 +899,8 @@ Orchestration maps this single parameter to each provider's native reasoning con
 
 :::note
 Anthropic Claude, GCP Gemini, and OpenAI reasoning models are among the models that expose reasoning content.
-Every reasoning model accepts the `reasoning_effort` values `minimal`, `low`, `medium`, `high`, and `none`, though each model maps them differently. You can also pass a model's native reasoning options directly.
+Every reasoning model accepts the `reasoning_effort` values `minimal`, `low`, `medium`, `high`, and `none`, though each model maps them differently.
+You can also pass a model's native reasoning options directly.
 See the [SAP AI Core reasoning documentation](https://help.sap.com/docs/sap-ai-core/generative-ai/reasoning?locale=en-US) for details.
 :::
 
@@ -925,9 +926,7 @@ const response = await orchestrationClient.chatCompletion({
 });
 
 const reasoning = response.getReasoningContent();
-if (reasoning) {
-  reasoning.forEach(block => console.log(block));
-}
+reasoning?.forEach(block => console.log(`<reasoning>${block}</reasoning>`));
 console.log(response.getContent());
 ```
 
@@ -1506,12 +1505,10 @@ const response = await orchestrationClient.stream({
 
 for await (const chunk of response.stream) {
   const reasoningDelta = chunk.getDeltaReasoningContent();
-  if (reasoningDelta) {
-    reasoningDelta.forEach(block => console.log(block));
-  }
+  reasoningDelta?.forEach(block => console.log(`<delta-reasoning>${block}</delta-reasoning>`));
 }
 
-const reasoning = response.getReasoningContent();
+const finalReasoning = response.getReasoningContent();
 ```
 
 ### Streaming with Tool Calls

--- a/docs-js/orchestration/chat-completion.mdx
+++ b/docs-js/orchestration/chat-completion.mdx
@@ -891,6 +891,65 @@ const usage = response.getTokenUsage();
 console.log('Cache details', usage?.prompt_tokens_details ?? usage);
 ```
 
+### Reasoning Content
+
+Some models can expose their intermediate reasoning steps in addition to the final answer.
+Enable reasoning by setting the harmonized `reasoning_effort` model parameter.
+Orchestration maps this single parameter to each provider's native reasoning configuration, so the same client code works across different models.
+
+Use the `getReasoningContent()` method to retrieve the reasoning content from the response.
+It returns an array of reasoning text blocks, or `undefined` when the model did not produce any reasoning content.
+
+:::note
+Reasoning content is only returned by models that support reasoning, such as Anthropic Claude, GCP Gemini, and OpenAI reasoning models.
+The set of supported `reasoning_effort` values (for example `low`, `medium`, and `high`) depends on the model.
+:::
+
+```ts twoslash
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
+
+const orchestrationClient = new OrchestrationClient({
+  promptTemplating: {
+    model: {
+      name: 'gemini-3.5-flash',
+      params: { reasoning_effort: 'high' }
+    }
+  }
+});
+
+const response = await orchestrationClient.chatCompletion({
+  messages: [
+    { role: 'user', content: 'Explain step by step: what is 15 * 17?' }
+  ]
+});
+
+const reasoning = response.getReasoningContent();
+if (reasoning) {
+  reasoning.forEach(block => console.log(block));
+}
+console.log(response.getContent());
+```
+
+To preserve the reasoning context across turns, pass the result of `getAllMessages()` as `messagesHistory` in the next request.
+The reasoning blocks are included in the returned messages automatically, so you do not need to handle them manually.
+
+```ts twoslash
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
+const orchestrationClient = new OrchestrationClient({
+  promptTemplating: {
+    model: { name: 'gemini-3.5-flash', params: { reasoning_effort: 'high' } }
+  }
+});
+const response = await orchestrationClient.chatCompletion({
+  messages: [{ role: 'user', content: 'Explain step by step: what is 15 * 17?' }]
+});
+// ---cut---
+const followUp = await orchestrationClient.chatCompletion({
+  messages: [{ role: 'user', content: 'Now do the same for 23 * 19.' }],
+  messagesHistory: response.getAllMessages()
+});
+```
+
 ### File Input
 
 Some models in the orchestration service accept files as input, such as PDFs, CSV files, Word documents, and audio files.
@@ -1412,6 +1471,42 @@ const response = await orchestrationClient.stream({ messages: [] });
 for await (const chunk of response.stream.toContentStream()) {
   console.log(chunk); // will log the delta content
 }
+```
+
+### Streaming Reasoning Content
+
+When streaming, reasoning content is delivered incrementally alongside the regular content.
+Use the `getDeltaReasoningContent()` method on each chunk to read the reasoning delta as it arrives.
+Use the `getReasoningContent()` method on the full response after the stream ends to read the accumulated reasoning content.
+
+Enable reasoning by setting the harmonized `reasoning_effort` model parameter, exactly as for non-streaming requests.
+
+```ts twoslash
+import { OrchestrationClient } from '@sap-ai-sdk/orchestration';
+// ---cut---
+const orchestrationClient = new OrchestrationClient({
+  promptTemplating: {
+    model: {
+      name: 'gemini-3.5-flash',
+      params: { reasoning_effort: 'high' }
+    }
+  }
+});
+
+const response = await orchestrationClient.stream({
+  messages: [
+    { role: 'user', content: 'Explain step by step: what is 15 * 17?' }
+  ]
+});
+
+for await (const chunk of response.stream) {
+  const reasoningDelta = chunk.getDeltaReasoningContent();
+  if (reasoningDelta) {
+    reasoningDelta.forEach(block => console.log(block));
+  }
+}
+
+const reasoning = response.getReasoningContent();
 ```
 
 ### Streaming with Tool Calls


### PR DESCRIPTION
## What Has Changed?

Adds \`Reasoning Content\` and \`Streaming Reasoning Content\` sections to docs-js/orchestration/chat-completion.mdx.

Covers the harmonized \`reasoning_effort\` parameter, \`getReasoningContent()\` / \`getDeltaReasoningContent()\`, and multi-turn reasoning via \`getAllMessages()\`.

Follow-up to SAP/ai-sdk-js#2057 (reasoning content feature). Closes documentation task in SAP/ai-sdk-js-backlog#616.