### PR TITLE
docs(openai): add streaming, stateful, and multi-turn examples for Responses API

### DIFF
--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -202,7 +202,9 @@ import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = [{ role: 'user' as const, content: 'What is the capital of France?' }];
+let context = [
+  { role: 'user' as const, content: 'What is the capital of France?' }
+];
 
 const first = await client.responses.create({ input: context });
 

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -276,7 +276,7 @@ if (toolCall && toolCall.type === 'function_call') {
   const input = [
     ...toResponseInputItems(response.output),
     {
-      type: 'function_call_output',
+      type: 'function_call_output' as const,
       call_id: toolCall.call_id,
       output: result
     }

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -202,9 +202,9 @@ import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = toResponseInputItems([
-  { role: 'user', content: 'What is the capital of France?' }
-]);
+let context = [
+  { role: 'user' as const, content: 'What is the capital of France?' }
+];
 
 const first = await client.responses.create({ input: context });
 

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -202,9 +202,9 @@ import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = toResponseInputItems([
+let context = [
   { role: 'user', content: 'What is the capital of France?' }
-]);
+];
 
 const first = await client.responses.create({ input: context });
 

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -202,9 +202,7 @@ import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = [
-  { role: 'user', content: 'What is the capital of France?' }
-];
+let context = [{ role: 'user', content: 'What is the capital of France?' }];
 
 const first = await client.responses.create({ input: context });
 

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -199,15 +199,16 @@ Use this when you need full control over the conversation history, for example t
 
 ```ts twoslash
 import { SapOpenAi } from '@sap-ai-sdk/openai';
+import type { ResponseInputItem } from 'openai';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context: any[] = [
+let context: ResponseInputItem[] = [
   { role: 'user', content: 'What is the capital of France?' }
 ];
 
 const first = await client.responses.create({ input: context });
 
-context = context.concat(first.output);
+context = context.concat(first.output as ResponseInputItem[]);
 context.push({
   role: 'user',
   content: 'What is the population of that city?'
@@ -243,6 +244,7 @@ The model returns a `function_call` in `response.output`; execute the function a
 
 ```ts twoslash
 import { SapOpenAi } from '@sap-ai-sdk/openai';
+import type { ResponseInputItem } from 'openai';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
 const response = await client.responses.create({
@@ -271,8 +273,8 @@ if (toolCall && toolCall.type === 'function_call') {
   // Call your actual function here.
   const result = JSON.stringify({ temperature: '15°C', condition: 'Cloudy' });
 
-  const input: any[] = [
-    ...response.output,
+  const input: ResponseInputItem[] = [
+    ...(response.output as ResponseInputItem[]),
     {
       type: 'function_call_output',
       call_id: toolCall.call_id,

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -200,9 +200,10 @@ Use this when you need full control over the conversation history, for example t
 ```ts twoslash
 import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = [
+let context: ResponseInputItem[] = [
   { role: 'user' as const, content: 'What is the capital of France?' }
 ];
 

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -236,6 +236,55 @@ const response = await client.responses.parse({
 });
 ```
 
+#### Tool Calling
+
+Use function tools to let the model call your own functions.
+The model returns a `function_call` in `response.output`; execute the function and send the result back in a follow-up request.
+
+```ts twoslash
+import { SapOpenAi } from '@sap-ai-sdk/openai';
+const client = await SapOpenAi.createClient('gpt-5.4');
+// ---cut---
+const response = await client.responses.create({
+  input: 'What is the weather in Paris?',
+  tools: [
+    {
+      type: 'function',
+      name: 'get_weather',
+      description: 'Get the current weather for a city.',
+      parameters: {
+        type: 'object',
+        properties: {
+          city: { type: 'string', description: 'The city name.' }
+        },
+        required: ['city'],
+        additionalProperties: false
+      },
+      strict: true
+    }
+  ]
+});
+
+const toolCall = response.output.find(item => item.type === 'function_call');
+if (toolCall && toolCall.type === 'function_call') {
+  const args = JSON.parse(toolCall.arguments); // { city: 'Paris' }
+  // Call your actual function here.
+  const result = JSON.stringify({ temperature: '15°C', condition: 'Cloudy' });
+
+  const input: any[] = [
+    ...response.output,
+    {
+      type: 'function_call_output',
+      call_id: toolCall.call_id,
+      output: result
+    }
+  ];
+
+  const finalResponse = await client.responses.create({ input });
+  // finalResponse.output_text contains the final answer.
+}
+```
+
 ## Per-Request Model Override
 
 You can override the model or deployment configuration for individual requests by passing a `model` parameter.

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -202,15 +202,15 @@ import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = [
-  { role: 'user' as const, content: 'What is the capital of France?' }
-];
+let context = toResponseInputItems([
+  { role: 'user', content: 'What is the capital of France?' }
+]);
 
 const first = await client.responses.create({ input: context });
 
 context = [...context, ...toResponseInputItems(first.output)];
 context.push({
-  role: 'user',
+  role: 'user' as const,
   content: 'What is the population of that city?'
 });
 

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -244,7 +244,7 @@ The model returns a `function_call` in `response.output`; execute the function a
 
 ```ts twoslash
 import { SapOpenAi } from '@sap-ai-sdk/openai';
-import type { ResponseInputItem } from 'openai';
+import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
 const response = await client.responses.create({
@@ -273,14 +273,14 @@ if (toolCall && toolCall.type === 'function_call') {
   // Call your actual function here.
   const result = JSON.stringify({ temperature: '15°C', condition: 'Cloudy' });
 
-  const input: ResponseInputItem[] = [
-    ...(response.output as ResponseInputItem[]),
+  const input = toResponseInputItems([
+    ...response.output,
     {
       type: 'function_call_output',
       call_id: toolCall.call_id,
       output: result
     }
-  ];
+  ]);
 
   const finalResponse = await client.responses.create({ input });
   // finalResponse.output_text contains the final answer.

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -199,16 +199,16 @@ Use this when you need full control over the conversation history, for example t
 
 ```ts twoslash
 import { SapOpenAi } from '@sap-ai-sdk/openai';
-import type { ResponseInputItem } from 'openai';
+import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context: ResponseInputItem[] = [
+let context = toResponseInputItems([
   { role: 'user', content: 'What is the capital of France?' }
-];
+]);
 
 const first = await client.responses.create({ input: context });
 
-context = context.concat(first.output as ResponseInputItem[]);
+context = [...context, ...toResponseInputItems(first.output)];
 context.push({
   role: 'user',
   content: 'What is the population of that city?'
@@ -273,14 +273,14 @@ if (toolCall && toolCall.type === 'function_call') {
   // Call your actual function here.
   const result = JSON.stringify({ temperature: '15°C', condition: 'Cloudy' });
 
-  const input = toResponseInputItems([
-    ...response.output,
+  const input = [
+    ...toResponseInputItems(response.output),
     {
       type: 'function_call_output',
       call_id: toolCall.call_id,
       output: result
     }
-  ]);
+  ];
 
   const finalResponse = await client.responses.create({ input });
   // finalResponse.output_text contains the final answer.

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -149,6 +149,75 @@ const response = await client.responses.create({
 });
 ```
 
+#### Streaming
+
+Pass `stream: true` and iterate over the events with `for await`.
+The `delta` text is only available when `event.type === 'response.output_text.delta'`.
+
+```ts twoslash
+import { SapOpenAi } from '@sap-ai-sdk/openai';
+const client = await SapOpenAi.createClient('gpt-5.4');
+// ---cut---
+const stream = await client.responses.create({
+  instructions: 'You are a helpful assistant.',
+  input: 'Give me a short introduction of SAP Cloud SDK.',
+  stream: true
+});
+
+for await (const event of stream) {
+  if (event.type === 'response.output_text.delta') {
+    process.stdout.write(event.delta);
+  }
+}
+```
+
+#### Stateful Conversations
+
+Pass `previous_response_id` to let the server maintain the conversation history.
+Each turn only needs to send the new message.
+Use this when you want simple multi-turn conversations without managing history yourself. Note that responses are stored on the server.
+
+```ts twoslash
+import { SapOpenAi } from '@sap-ai-sdk/openai';
+const client = await SapOpenAi.createClient('gpt-5.4');
+// ---cut---
+const first = await client.responses.create({
+  instructions: 'You are a helpful assistant.',
+  input: 'What is the capital of France?'
+});
+
+const second = await client.responses.create({
+  previous_response_id: first.id,
+  input: 'What is the population of that city?'
+});
+```
+
+#### Multi-Turn Conversations
+
+Manage the context yourself by appending the previous `response.output` to the next `input`.
+Use this when you need full control over the conversation history, for example to store it in your own database or modify messages between turns.
+
+```ts twoslash
+import { SapOpenAi } from '@sap-ai-sdk/openai';
+const client = await SapOpenAi.createClient('gpt-5.4');
+// ---cut---
+let context: any[] = [
+  { role: 'user', content: 'What is the capital of France?' }
+];
+
+const first = await client.responses.create({ input: context });
+
+context = context.concat(first.output);
+context.push({
+  role: 'user',
+  content: 'What is the population of that city?'
+});
+
+const second = await client.responses.create({ input: context });
+```
+
+#### Structured Output
+
 Use the `parse()` method for structured output with a Zod schema:
 
 ```ts twoslash

--- a/docs-js/openai/openai.mdx
+++ b/docs-js/openai/openai.mdx
@@ -202,7 +202,7 @@ import { SapOpenAi } from '@sap-ai-sdk/openai';
 import { toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
 const client = await SapOpenAi.createClient('gpt-5.4');
 // ---cut---
-let context = [{ role: 'user', content: 'What is the capital of France?' }];
+let context = [{ role: 'user' as const, content: 'What is the capital of France?' }];
 
 const first = await client.responses.create({ input: context });
 


### PR DESCRIPTION
## Related Issues
https://github.com/SAP/ai-sdk-js-backlog/issues/651

## What Has Changed?

The Responses API section only had `create()` and `parse()` examples. Added three sub-sections with code and when-to-use guidance:

- Streaming — `stream: true` + `for await` loop
- Stateful Conversations — `previous_response_id` (server manages history)
- Multi-Turn Conversations — manual context via `response.output` concat

Also added a `#### Structured Output` header to the existing `parse()` block (it had become orphaned structurally), and simplified the multi-turn example to use `any[]` directly instead of an internal `openai/lib/` import.
