### PR TITLE
docs: Update deprecated models table

### DIFF
--- a/docs-js/overview.mdx
+++ b/docs-js/overview.mdx
@@ -109,6 +109,9 @@ For retired models, refer to the **Recently Retired Models** table in the SAP no
 | `gpt-4.1-mini`                      |                                                    |
 | `o3`                                |                                                    |
 | `o4-mini`                           |                                                    |
+| `mistralai--mistral-large-instruct` |                                                    |
+| `gemini-2.5-flash`                  |                                                    |
+| `gemini-2.5-pro`                    |                                                    |
 
 ## Contribute, Support and Feedback
 


### PR DESCRIPTION
Sync of the deprecated models table in `docs-js/overview.mdx` from [SAP Notes 3437766](https://me.sap.com/notes/3437766).

## Changes

- Added newly deprecated models: `mistralai--mistral-large-instruct`, `gpt-4.1-nano`, `gemini-2.5-flash`, `gemini-2.5-pro`

## Definition of Done
- [ ] Table entries are correct
- [ ] Retired models removed
- [ ] Replacement suggestions accurate