### PR TITLE
feat: enable Python navbar item and fix homepage Get Started link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,7 +75,7 @@ export default {
           position: 'left',
           docsPluginId: 'docs-python',
           activeBasePath: 'docs/python',
-          className: 'navbar-item-invisible'
+          sdkSwitch: true
         },
         {
           type: 'docsVersionDropdown',

--- a/src/pages/components/HomepageFeatures.js
+++ b/src/pages/components/HomepageFeatures.js
@@ -59,7 +59,7 @@ const FeatureList = [
   },
   {
     title: <>SAP Cloud SDK for AI (Python)</>,
-    link: 'https://help.sap.com/doc/generative-ai-hub-sdk/CLOUD/en-US/index.html',
+    link: 'docs/python/overview',
     Svg: () => <span style={{ fontSize: '200px' }}>🐍</span>,
     badge: (
       <>
@@ -80,9 +80,7 @@ const FeatureList = [
     ),
     description: (
       <div data-nosnippet>
-        <a href="https://help.sap.com/doc/generative-ai-hub-sdk/CLOUD/en-US/index.html">
-          Get Started
-        </a>
+        <a href="docs/python/overview">Get Started</a>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

- Show the Python SDK navbar item alongside Java and JavaScript by replacing
  `className: 'navbar-item-invisible'` with `sdkSwitch: true` in `docusaurus.config.js`
- Fix the Python "Get Started" button and logo link on the homepage to point to the
  internal docs page (`docs/python/overview`) instead of the external SAP Help Portal

## Changes

- `docusaurus.config.js`: enable Python navbar item
- `src/pages/components/HomepageFeatures.js`: update Python Get Started link to internal page

## Test

1. Run `npm start` locally
2. Verify the Python 🐍 tab appears in the navbar alongside ☕ Java and 🚀 JavaScript
3. On the homepage, click the Python logo and "Get Started" button — both should navigate to `/ai-sdk/docs/python/overview`

## Acceptance Criteria

- [ ] The new docusaurus based documentation is exposed via the links/buttons like other languages 
